### PR TITLE
cmd/dit: add -p precision flag

### DIFF
--- a/cmd/dit/main.go
+++ b/cmd/dit/main.go
@@ -1,14 +1,26 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"time"
 
 	"github.com/alrs/dit"
 )
 
+var precise bool
+
+func init() {
+	flag.BoolVar(&precise, "p", false, "show desek")
+	flag.Parse()
+}
+
 func main() {
 	now := time.Now()
 	d := dit.TimeToDIT(now)
-	fmt.Println(d)
+	if precise {
+		fmt.Println(d)
+	} else {
+		fmt.Printf("%d:%d\n", d.Dec(), d.Decim())
+	}
 }


### PR DESCRIPTION
This adds a `-p` flag to the cli command to opt-in to "desek" precision.